### PR TITLE
Have mcp server print tool names as typescript interface names instead of utcp tool names

### DIFF
--- a/code-mode-mcp/package.json
+++ b/code-mode-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/code-mode-mcp",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Model Context Protocol (MCP) server for UTCP Code Mode - Execute TypeScript code with direct tool access",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
fixes #15 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch MCP server tool name output to TypeScript interface-style names and add flexible lookup by either UTCP or TypeScript name. This makes tool discovery consistent and reduces confusion when working with TypeScript interfaces.

- **New Features**
  - Show TypeScript interface names in tool search and list outputs.
  - Resolve tools by either UTCP name or TypeScript interface name for variable and interface prompts.
  - Add identifier sanitization and name conversion to ensure valid, predictable TypeScript names.

<sup>Written for commit 13dbfad17ca5ae5146d98d2f18d78eee64664b69. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

