### PR TITLE
Override console.log and console.warn to align with MCP specification

### DIFF
--- a/code-mode-mcp/index.ts
+++ b/code-mode-mcp/index.ts
@@ -3,6 +3,7 @@
 // UTCP-MCP Bridge Entry Point
 // This is the main entry point for the npx @utcp/mcp-bridge command
 
+import util from "util";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -34,6 +35,10 @@ import { ContentBlock, ContentBlockSchema } from "@modelcontextprotocol/sdk/type
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+// Override info and warn logs in simple manner to keep compatibility with MCP stdio transport
+console.log = (...args: any[]) => { process.stderr.write(util.format(...args) + '\n'); }
+console.warn = (...args: any[]) => { process.stderr.write(util.format(...args) + '\n'); }
 
 ensureCorePluginsInitialized();
 


### PR DESCRIPTION
I've reviewed [specifications](https://modelcontextprotocol.io/legacy/tools/debugging#server-side-logging) for MCP STDIO servers output and decided to override log and warn console methods to write out information to stderr, as specificatoin states:

> all messages logged to stderr (standard error) will be captured by the host application (e.g., Claude Desktop) automatically.

In this case we still have info from UTCP modules - either in command line or any MCP client with strict stdout handling.
This should be the most accurate way to convert log output from UTCP modules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Override console.log and console.warn to write to stderr per MCP STDIO spec. This keeps stdout reserved for MCP messages and ensures logs are captured by host apps like Claude Desktop.

<sup>Written for commit b23060674b8cbe16bb6a102f9eed75b01f501cb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

