### PR TITLE
add dev scripts for local Claude Code MCP testing + install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Connect to any Model Context Protocol server:
 > package once at startup so it can register itself with the client; the plugin
 > registers as a side effect of being imported. For `mcp`, that's `@utcp/mcp`.
 > The same pattern applies to other transports: `@utcp/http`, `@utcp/text`, etc.
+>
+> ```bash
+> npm install @utcp/mcp
+> ```
 
 ```typescript
 import '@utcp/mcp';                      // registers the 'mcp' call template

--- a/README.md
+++ b/README.md
@@ -153,7 +153,13 @@ npm install @utcp/code-mode
 ### 1. **MCP Server Integration**
 Connect to any Model Context Protocol server:
 
+> Each `call_template_type` is a separate plugin package. Install and import the
+> package once at startup so it can register itself with the client; the plugin
+> registers as a side effect of being imported. For `mcp`, that's `@utcp/mcp`.
+> The same pattern applies to other transports: `@utcp/http`, `@utcp/text`, etc.
+
 ```typescript
+import '@utcp/mcp';                      // registers the 'mcp' call template
 import { CodeModeUtcpClient } from '@utcp/code-mode';
 
 const client = await CodeModeUtcpClient.create();
@@ -165,6 +171,7 @@ await client.registerManual({
   config: {
     mcpServers: {
       github: {
+        transport: 'stdio',              // required by @utcp/mcp
         command: 'docker',
         args: ['run', '-i', '--rm', '-e', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'mcp/github'],
         env: { GITHUB_PERSONAL_ACCESS_TOKEN: process.env.GITHUB_TOKEN }

--- a/code-mode-mcp/README.md
+++ b/code-mode-mcp/README.md
@@ -65,18 +65,17 @@ Create a `.utcp_config.json` file to configure your tools and services:
 }
 ```
 
-### Enabling CLI Support
+### Protocol plugins
 
-**Important:** CLI protocol support is **disabled by default** for security reasons. To enable CLI tool execution, you need to explicitly register the CLI plugin in 'index.ts'.
+Each `call_template_type` (`http`, `mcp`, `cli`, `text`, `file`, ...) lives in
+its own `@utcp/<name>` package and registers itself as a side effect of being
+imported — the bridge already imports the bundled set in
+[`index.ts`](./index.ts). To add a new transport, install the package and add
+a top-level `import "@utcp/<name>"` line; no manual `register()` call needed.
 
-```typescript
-import { register as registerCli } from "@utcp/cli";
-
-// Enable CLI support
-registerCli();
-```
-
-**Security Note:** Only enable CLI if you trust the code that will be executed, as CLI tools can execute arbitrary commands on your system.
+**Security note:** the `@utcp/cli` plugin lets a manual run arbitrary local
+commands. It's bundled and active by default; only register manuals from
+sources you trust.
 
 ### Claude Code (CLI)
 
@@ -134,7 +133,7 @@ The Universal Tool Calling Protocol (UTCP) allows you to:
 
 With this MCP bridge, all your UTCP tools become available in Claude Desktop and other MCP clients.
  
-**Optional Protocols:** CLI requires explicit registration for security (see "Enabling CLI Support" above).
+**Security note:** `@utcp/cli` allows manuals to run arbitrary local commands — only register manuals from sources you trust.
 
 ## 💻 Code Mode Example
 

--- a/code-mode-mcp/README.md
+++ b/code-mode-mcp/README.md
@@ -78,6 +78,40 @@ registerCli();
 
 **Security Note:** Only enable CLI if you trust the code that will be executed, as CLI tools can execute arbitrary commands on your system.
 
+### Claude Code (CLI)
+
+For [Claude Code](https://claude.com/claude-code) (the CLI / IDE extension), register the bridge as a user-scoped MCP server:
+
+```bash
+claude mcp add-json --scope user utcp-codemode '{"type":"stdio","command":"npx","args":["@utcp/code-mode-mcp"],"env":{"UTCP_CONFIG_FILE":"/absolute/path/to/.utcp_config.json"}}'
+```
+
+Then restart Claude Code. Verify with `claude mcp list`. Remove with `claude mcp remove utcp-codemode --scope user`.
+
+## 🧪 Local development against the bridge
+
+If you're hacking on `@utcp/code-mode` (the sibling `typescript-library/` package) and want to exercise it through Claude Code, use the dev scripts:
+
+```bash
+cd code-mode-mcp
+npm install
+npm run dev:register     # builds lib + bridge, overlays the lib build into the bridge's node_modules, registers as 'utcp-codemode-dev' in Claude Code
+# restart Claude Code, then call mcp__utcp-codemode-dev__call_tool_chain to test
+
+# After every edit:
+npm run dev:register     # rebuilds, re-registers; restart Claude Code
+
+# When done:
+npm run dev:unregister   # removes the MCP entry and restores the registry @utcp/code-mode
+```
+
+Both scripts are idempotent and never mutate `package.json`. The overlay strategy avoids `npm link`, which under modern npm aliases `unlink` to `uninstall --save` and would silently strip the dependency.
+
+Flags:
+
+- `--name <mcp-name>` (default `utcp-codemode-dev`) — useful if you want the dev bridge alongside a published one
+- `--config <path>` (default `./.utcp_config.json`) — point at a different UTCP config
+
 ## 🛠️ Available MCP Tools
 
 The bridge exposes these MCP tools for managing your UTCP Code Mode ecosystem:

--- a/code-mode-mcp/index.ts
+++ b/code-mode-mcp/index.ts
@@ -173,6 +173,11 @@ Remember: The power of this system comes from combining multiple tools in sophis
             task_description: z.string().describe("A natural language description of the task."),
             limit: z.number().optional().default(10),
         },
+        annotations: {
+            readOnlyHint: true,
+            openWorldHint: false,
+            idempotentHint: true,
+        },
     }, async (input) => {
         const client = await initializeUtcpClient();
         try {
@@ -192,6 +197,11 @@ Remember: The power of this system comes from combining multiple tools in sophis
         title: "List All Registered UTCP Tools",
         description: "Returns a list of all tool names currently registered.",
         inputSchema: {},
+        annotations: {
+            readOnlyHint: true,
+            openWorldHint: false,
+            idempotentHint: true,
+        },
     }, async () => {
         const client = await initializeUtcpClient();
         try {
@@ -208,6 +218,11 @@ Remember: The power of this system comes from combining multiple tools in sophis
         description: "Get required environment variables for a registered tool.",
         inputSchema: {
             tool_name: z.string().describe("Name of the tool to get required variables for."),
+        },
+        annotations: {
+            readOnlyHint: true,
+            openWorldHint: false,
+            idempotentHint: true,
         },
     }, async (input) => {
         const client = await initializeUtcpClient();
@@ -228,6 +243,11 @@ Remember: The power of this system comes from combining multiple tools in sophis
         description: "Get complete information about a specified list of tools, including TypeScript interface definition.",
         inputSchema: {
             tool_names: z.array(z.string()).describe("Names of the tools to get complete information for."),
+        },
+        annotations: {
+            readOnlyHint: true,
+            openWorldHint: false,
+            idempotentHint: true,
         },
     }, async (input) => {
         const client = await initializeUtcpClient();

--- a/code-mode-mcp/package-lock.json
+++ b/code-mode-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@utcp/code-mode-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@utcp/code-mode-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.2",
@@ -795,7 +795,7 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
@@ -1224,7 +1224,7 @@
       "license": "MIT"
     },
     "node_modules/send": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
       "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
       "license": "MIT",
@@ -1261,7 +1261,7 @@
       }
     },
     "node_modules/setprototypeof": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"

--- a/code-mode-mcp/package-lock.json
+++ b/code-mode-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@utcp/code-mode-mcp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@utcp/code-mode-mcp",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.2",
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@utcp/code-mode": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@utcp/code-mode/-/code-mode-1.2.11.tgz",
-      "integrity": "sha512-nCDB1CXB56A1/0lFPuybeul4/3SkobVpP9xav/CvoFp+KAFPKH30OpQUVq8/8BHIN0cPYCrXwViivUyrxk6H+A==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@utcp/code-mode/-/code-mode-1.2.12.tgz",
+      "integrity": "sha512-LnqLrrQfIVVGl2s5poF72CiN217UDcqpGK12oteEg6kI4eYK53sCg66Y6fp59oq6TvJl22QMR5xmjHBY1KrahQ==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -284,39 +284,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -335,31 +302,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -399,13 +341,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -502,32 +437,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -544,16 +453,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -595,16 +494,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -686,16 +575,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -869,13 +748,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -921,13 +793,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -1017,39 +882,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1073,14 +910,14 @@
       "license": "ISC"
     },
     "node_modules/isolated-vm": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.0.2.tgz",
-      "integrity": "sha512-Qw6AJuagG/VJuh2AIcSWmQPsAArti/L+lKhjXU+lyhYkbt3J57XZr+ZjgfTnOr4NJcY1r3f8f0eePS7MRGp+pg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
+      "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
       "hasInstallScript": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "prebuild-install": "^7.1.3"
+        "node-gyp-build": "^4.8.4"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1155,48 +992,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -1207,17 +1007,16 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {
@@ -1299,33 +1098,6 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1344,17 +1116,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -1411,37 +1172,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "peer": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1492,19 +1222,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/send": {
       "version": "1.2.0",
@@ -1642,53 +1359,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1698,56 +1368,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1755,19 +1375,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -1813,13 +1420,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/code-mode-mcp/package.json
+++ b/code-mode-mcp/package.json
@@ -14,7 +14,9 @@
   "scripts": {
     "build": "node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc",
     "prepublishOnly": "npm run build",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "dev:register": "node scripts/dev-register.mjs",
+    "dev:unregister": "node scripts/dev-unregister.mjs"
   },
   "keywords": [
     "utcp",

--- a/code-mode-mcp/package.json
+++ b/code-mode-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/code-mode-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Model Context Protocol (MCP) server for UTCP Code Mode - Execute TypeScript code with direct tool access",
   "type": "module",
   "main": "dist/index.js",

--- a/code-mode-mcp/scripts/dev-register.mjs
+++ b/code-mode-mcp/scripts/dev-register.mjs
@@ -33,6 +33,16 @@ const getArg = (flag, fallback) => {
 const name = getArg("--name", "utcp-codemode-dev");
 const configPath = path.resolve(bridgeDir, getArg("--config", ".utcp_config.json"));
 
+// Validate --name against the same character set Claude Code's managed-server
+// schema accepts ([a-zA-Z0-9_-]). The value is later interpolated into a shell
+// command string (because Windows .cmd shims require shell: true and cmd.exe
+// won't strip our JSON quoting otherwise), so anything outside this set could
+// break out of the argument and execute attacker-supplied commands.
+if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+  console.error(`✗ Invalid --name '${name}'. Must match [a-zA-Z0-9_-]+.`);
+  process.exit(1);
+}
+
 if (!existsSync(configPath)) {
   console.error(`✗ Config file not found: ${configPath}`);
   console.error(`  Pass --config <path> or create one at ${configPath}.`);

--- a/code-mode-mcp/scripts/dev-register.mjs
+++ b/code-mode-mcp/scripts/dev-register.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Wire up the local code-mode-mcp bridge as an MCP server in Claude Code,
+// pointed at the local @utcp/code-mode build so edits in ../typescript-library
+// flow through after rebuild + Claude Code restart.
+//
+// Strategy: overlay the locally-built dist/ on top of the registry version
+// inside node_modules. We avoid `npm link` because modern npm treats `npm
+// unlink <pkg>` as `npm uninstall --save`, which mutates package.json.
+//
+// Usage:
+//   node scripts/dev-register.mjs [--name <mcp-name>] [--config <path>]
+//
+// Defaults:
+//   --name    utcp-codemode-dev
+//   --config  ./.utcp_config.json (relative to bridge package)
+
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.resolve(__dirname, "..");
+const libDir = path.resolve(bridgeDir, "..", "typescript-library");
+
+const args = process.argv.slice(2);
+const getArg = (flag, fallback) => {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const name = getArg("--name", "utcp-codemode-dev");
+const configPath = path.resolve(bridgeDir, getArg("--config", ".utcp_config.json"));
+
+if (!existsSync(configPath)) {
+  console.error(`✗ Config file not found: ${configPath}`);
+  console.error(`  Pass --config <path> or create one at ${configPath}.`);
+  process.exit(1);
+}
+if (!existsSync(libDir)) {
+  console.error(`✗ Sibling library not found at ${libDir}.`);
+  process.exit(1);
+}
+
+function run(cmd, args, opts = {}) {
+  console.log(`> ${cmd} ${args.join(" ")}  (in ${opts.cwd ?? process.cwd()})`);
+  const r = spawnSync(cmd, args, { stdio: "inherit", shell: true, ...opts });
+  if (r.status !== 0) {
+    console.error(`✗ Command failed (exit ${r.status}).`);
+    process.exit(r.status ?? 1);
+  }
+}
+
+// 1. Make sure the bridge has its registry deps installed (provides
+//    node_modules/@utcp/code-mode for us to overlay onto).
+if (!existsSync(path.join(bridgeDir, "node_modules", "@utcp", "code-mode"))) {
+  run("npm", ["install"], { cwd: bridgeDir });
+}
+
+// 2. Build the local lib so dist/ is current.
+run("npm", ["run", "build"], { cwd: libDir });
+
+// 3. Overlay the local lib's dist/ over the registry copy in the bridge's
+//    node_modules. This is non-destructive — `npm install` later restores the
+//    registry version.
+const localDist = path.join(libDir, "dist");
+const targetDist = path.join(bridgeDir, "node_modules", "@utcp", "code-mode", "dist");
+console.log(`> overlay  ${localDist}  ->  ${targetDist}`);
+rmSync(targetDist, { recursive: true, force: true });
+mkdirSync(targetDist, { recursive: true });
+cpSync(localDist, targetDist, { recursive: true });
+
+// 4. Build the bridge against the overlaid lib.
+run("npm", ["run", "build"], { cwd: bridgeDir });
+
+// 5. Register with Claude Code (user scope). Removes a stale entry first so the
+//    command is idempotent.
+spawnSync("claude", ["mcp", "remove", name, "--scope", "user"], {
+  stdio: "ignore",
+  shell: true,
+});
+
+const distEntry = path.join(bridgeDir, "dist", "index.js").replace(/\\/g, "/");
+const cfg = configPath.replace(/\\/g, "/");
+const mcpJson = JSON.stringify({
+  type: "stdio",
+  command: "node",
+  args: [distEntry],
+  env: { UTCP_CONFIG_FILE: cfg },
+});
+
+const isWindows = os.platform() === "win32";
+const quotedJson = isWindows
+  ? `"${mcpJson.replace(/"/g, '\\"')}"`
+  : `'${mcpJson.replace(/'/g, `'\\''`)}'`;
+
+const cmdLine = `claude mcp add-json --scope user ${name} ${quotedJson}`;
+console.log(`> ${cmdLine}`);
+const r = spawnSync(cmdLine, { stdio: "inherit", shell: true });
+if (r.status !== 0) {
+  console.error(`✗ claude mcp add-json failed (exit ${r.status}).`);
+  process.exit(r.status ?? 1);
+}
+
+console.log(`\n✓ Registered MCP server '${name}' (user scope).`);
+console.log(`  Entry:  ${distEntry}`);
+console.log(`  Config: ${cfg}`);
+console.log(`\nRestart Claude Code to load the server. Then call`);
+console.log(`'mcp__${name}__call_tool_chain' to test changes.`);
+console.log(`\nAfter editing the library or bridge, re-run this script to rebuild +`);
+console.log(`re-register, then restart Claude Code again.`);

--- a/code-mode-mcp/scripts/dev-unregister.mjs
+++ b/code-mode-mcp/scripts/dev-unregister.mjs
@@ -21,15 +21,42 @@ const getArg = (flag, fallback) => {
 
 const name = getArg("--name", "utcp-codemode-dev");
 
-function run(cmd, args, opts = {}) {
-  console.log(`> ${cmd} ${args.join(" ")}  (in ${opts.cwd ?? process.cwd()})`);
-  spawnSync(cmd, args, { stdio: "inherit", shell: true, ...opts });
+if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+  console.error(`✗ Invalid --name '${name}'. Must match [a-zA-Z0-9_-]+.`);
+  process.exit(1);
 }
 
-run("claude", ["mcp", "remove", name, "--scope", "user"]);
+let hadFailure = false;
+
+// `claude mcp remove` is allowed to fail (entry may already be gone) — log
+// but don't abort the rest of the cleanup. Other steps must succeed for the
+// success message to be honest.
+function tryRun(cmd, args, opts = {}) {
+  console.log(`> ${cmd} ${args.join(" ")}  (in ${opts.cwd ?? process.cwd()})`);
+  const r = spawnSync(cmd, args, { stdio: "inherit", shell: true, ...opts });
+  if (r.status !== 0) {
+    console.warn(`⚠ ${cmd} ${args[0] ?? ""} exited ${r.status}; continuing.`);
+  }
+}
+
+function mustRun(cmd, args, opts = {}) {
+  console.log(`> ${cmd} ${args.join(" ")}  (in ${opts.cwd ?? process.cwd()})`);
+  const r = spawnSync(cmd, args, { stdio: "inherit", shell: true, ...opts });
+  if (r.status !== 0) {
+    console.error(`✗ ${cmd} ${args[0] ?? ""} failed (exit ${r.status}).`);
+    hadFailure = true;
+  }
+}
+
+tryRun("claude", ["mcp", "remove", name, "--scope", "user"]);
 // Reinstall @utcp/code-mode from the registry, undoing the dev-register dist
 // overlay. --no-save keeps package.json untouched.
-run("npm", ["install", "@utcp/code-mode", "--no-save"], { cwd: bridgeDir });
+mustRun("npm", ["install", "@utcp/code-mode", "--no-save"], { cwd: bridgeDir });
+
+if (hadFailure) {
+  console.error(`\n✗ Unregister completed with errors. Registry @utcp/code-mode may not have been restored — re-run 'npm install' manually before publishing.`);
+  process.exit(1);
+}
 
 console.log(`\n✓ Unregistered '${name}' and restored registry @utcp/code-mode.`);
 console.log(`  Restart Claude Code so it stops trying to spawn the dev bridge.`);

--- a/code-mode-mcp/scripts/dev-unregister.mjs
+++ b/code-mode-mcp/scripts/dev-unregister.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Tear down what dev-register.mjs set up: deregister the Claude Code MCP server
+// and restore the registry version of @utcp/code-mode (overwrites the local
+// dist/ overlay).
+//
+// Usage:
+//   node scripts/dev-unregister.mjs [--name <mcp-name>]
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const getArg = (flag, fallback) => {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const name = getArg("--name", "utcp-codemode-dev");
+
+function run(cmd, args, opts = {}) {
+  console.log(`> ${cmd} ${args.join(" ")}  (in ${opts.cwd ?? process.cwd()})`);
+  spawnSync(cmd, args, { stdio: "inherit", shell: true, ...opts });
+}
+
+run("claude", ["mcp", "remove", name, "--scope", "user"]);
+// Reinstall @utcp/code-mode from the registry, undoing the dev-register dist
+// overlay. --no-save keeps package.json untouched.
+run("npm", ["install", "@utcp/code-mode", "--no-save"], { cwd: bridgeDir });
+
+console.log(`\n✓ Unregistered '${name}' and restored registry @utcp/code-mode.`);
+console.log(`  Restart Claude Code so it stops trying to spawn the dev bridge.`);


### PR DESCRIPTION
- code-mode-mcp/scripts/dev-{register,unregister}.mjs: build the local typescript-library, overlay its dist into the bridge's node_modules, and (un)register the bridge with `claude mcp add-json --scope user`. Idempotent and never mutates package.json. Avoids `npm link` because modern npm aliases `unlink <pkg>` to `uninstall --save`, which silently strips the dependency from package.json.

- README: add a `claude mcp add-json` snippet for Claude Code users alongside the existing Claude Desktop one, plus a "Local development against the bridge" section describing `npm run dev:register` / `dev:unregister`.

- package-lock.json: resolves @utcp/code-mode to 1.2.12 (the just- published fix for the call_tool_chain async-result bug).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dev scripts to register a local MCP bridge for Claude Code against a local `@utcp/code-mode` build, and updates docs for plugin imports and Claude Code CLI setup. Also adds read-only annotations to discovery tools and bumps `@utcp/code-mode-mcp` to 1.2.1 and `@utcp/code-mode` to 1.2.12.

- **New Features**
  - `npm run dev:register` / `npm run dev:unregister`: build, overlay local `@utcp/code-mode` into the bridge, and (un)register a user-scoped MCP server in Claude Code (default `utcp-codemode-dev`). Supports `--name` and `--config`.
  - Docs: explain side-effect plugin imports, add `npm install @utcp/mcp`, require `transport: 'stdio'`, add Claude Code CLI snippet, and replace the outdated “Enable CLI” section with a note that `@utcp/cli` auto-registers (with a security warning).

- **Bug Fixes**
  - Add MCP annotations (`readOnlyHint`, `openWorldHint: false`, `idempotentHint`) to `search_tools`, `list_tools`, `get_required_keys_for_tool`, `tools_info` to avoid write confirmations.
  - Script hardening: validate `--name` as `[a-zA-Z0-9_-]+` to prevent shell injection; ensure unregister propagates failures.

<sup>Written for commit abe2743da36e2214e4143b147ffa41da0175fafe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

