### PR TITLE
Dev

### DIFF
--- a/python-library/README.md
+++ b/python-library/README.md
@@ -245,20 +245,25 @@ Tools can dynamically discover and adapt to available interfaces:
 ```python
 result = await client.call_tool_chain('''
 # Discover available tools at runtime
-print('Available interfaces:', __interfaces)
+print('Available interfaces:', interfaces)
 
 # Get specific tool interface for validation
-pr_interface = __get_tool_interface('github.get_pull_request')
+pr_interface = get_tool_interface('github.get_pull_request')
 print('PR tool expects:', pr_interface)
 
 # Use interface info for dynamic workflows
-has_slack_tools = 'namespace slack' in __interfaces
+has_slack_tools = 'namespace slack' in interfaces
 if has_slack_tools:
     await slack.post_message(channel='#dev', text='Analysis complete')
 
 return {"toolsAvailable": has_slack_tools}
 ''')
 ```
+
+> Note: `interfaces` and `get_tool_interface` are exposed under plain names
+> because the RestrictedPython sandbox rejects identifiers that start with an
+> underscore at compile time. Earlier versions documented `__interfaces` /
+> `__get_tool_interface`, which were unreachable from user code.
 
 ### **Context-Efficient Data Processing**
 Process large datasets without bloating the model's context:
@@ -361,9 +366,9 @@ response = client.chat.completions.create(
 ```
 
 **The template provides comprehensive guidance on:**
-- Tool discovery workflow (`search_tools` → `__interfaces` → `call_tool_chain`)
+- Tool discovery workflow (`search_tools` → `interfaces` → `call_tool_chain`)
 - Hierarchical access patterns (`manual.tool()` syntax)  
-- Interface introspection (`__get_tool_interface()`)
+- Interface introspection (`get_tool_interface()`)
 - Error handling and best practices
 
 ---

--- a/python-library/pyproject.toml
+++ b/python-library/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "code-mode"
-version = "0.0.3"
+version = "1.1.0"
 authors = [
   { name = "UTCP Contributors" },
 ]
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.0",
-    "utcp>=1.0",
+    "utcp>=1.1.2",
     "typing-extensions>=4.0",
     "RestrictedPython>=6.0"
 ]

--- a/python-library/src/utcp_code_mode/code_mode_utcp_client.py
+++ b/python-library/src/utcp_code_mode/code_mode_utcp_client.py
@@ -68,8 +68,8 @@ You have access to a CodeModeUtcpClient that allows you to execute Python code w
 
 ### 2. Interface Introspection
 **Understand tool contracts before using them:**
-- Access `__interfaces` to see all available Python type definitions
-- Use `__get_tool_interface('manual.tool')` to get specific tool interfaces
+- Access `interfaces` to see all available Python type definitions
+- Use `get_tool_interface('manual.tool')` to get specific tool interfaces
 - Interfaces show required inputs, expected outputs, and descriptions
 - Look for "Access as: manual.tool(args)" comments for usage patterns
 
@@ -93,10 +93,14 @@ You have access to a CodeModeUtcpClient that allows you to execute Python code w
 - **Return values**: Use `return your_value` to return a value from code execution
 
 ### 5. Available Runtime Context
-- `__interfaces`: String containing all Python type definitions
-- `__get_tool_interface(tool_name)`: Function to get specific tool interface
+- `interfaces`: String containing all Python type definitions
+- `get_tool_interface(tool_name)`: Function to get specific tool interface
 - All registered tools as `manual.tool` synchronous functions
 - Standard Python built-ins for data processing
+
+Note: Names starting with an underscore are reserved by the RestrictedPython
+sandbox and cannot be referenced from user code, so the runtime context uses
+plain names without leading underscores.
 
 Remember: Always discover and understand available tools before attempting to use them in code execution.
 """.strip()
@@ -424,9 +428,11 @@ import asyncio
             'time': __import__('time'),
             're': __import__('re'),
             
-            # Add Python interface definitions for reference
-            '__interfaces': await self.get_all_tools_python_interfaces(),
-            '__get_tool_interface': lambda tool_name: (
+            # Tool interface helpers — exposed under plain names because
+            # RestrictedPython rejects identifiers that start with an
+            # underscore at compile time.
+            'interfaces': await self.get_all_tools_python_interfaces(),
+            'get_tool_interface': lambda tool_name: (
                 self.tool_to_python_interface(tool)
                 if (tool := next((t for t in tools if t.name == tool_name), None))
                 else None

--- a/python-library/tests/test_code_mode_utcp_client.py
+++ b/python-library/tests/test_code_mode_utcp_client.py
@@ -184,6 +184,32 @@ return weather_data
         assert "Weather result:" in result["logs"][0]
 
     @pytest.mark.asyncio
+    async def test_call_tool_chain_can_reference_interfaces(self, code_mode_client, mock_base_client, sample_tool):
+        """Regression test for issue #24: `interfaces` and `get_tool_interface`
+        must be reachable from sandboxed user code. RestrictedPython rejects
+        identifiers that start with an underscore at compile time, so the
+        previous `__interfaces` / `__get_tool_interface` names were unreachable
+        even though the context dict contained them.
+        """
+        client = code_mode_client
+        base_client = mock_base_client
+
+        base_client.config.tool_repository.get_tools.return_value = [sample_tool]
+
+        code = """
+own_iface = get_tool_interface("weather.get_current_weather")
+return {
+    "interfaces_is_str": isinstance(interfaces, str) and len(interfaces) > 0,
+    "iface_mentions_tool": "get_current_weather" in (own_iface or ""),
+}
+"""
+
+        result = await client.call_tool_chain(code)
+
+        assert result["result"]["interfaces_is_str"] is True
+        assert result["result"]["iface_mentions_tool"] is True
+
+    @pytest.mark.asyncio
     async def test_call_tool_chain_error_handling(self, code_mode_client, mock_base_client):
         """Test error handling in code execution."""
         client = code_mode_client
@@ -262,12 +288,12 @@ return len(result)
         assert "__import__" in context
         
         # Check tool-related items
-        assert "__interfaces" in context
-        assert "__get_tool_interface" in context
+        assert "interfaces" in context
+        assert "get_tool_interface" in context
         assert "weather" in context
-        
+
         # Test the tool interface function
-        interface = context["__get_tool_interface"]("weather.get_current_weather")
+        interface = context["get_tool_interface"]("weather.get_current_weather")
         assert interface is not None
         assert "get_current_weather" in interface
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose tool interface helpers in the sandbox as interfaces and get_tool_interface (replacing __interfaces/__get_tool_interface) so user code runs under RestrictedPython without compile-time errors. Updated docs/tests, and released `code-mode` 1.1.0 with `utcp` >= 1.1.2.

- **Bug Fixes**
  - Expose `interfaces` and `get_tool_interface` in the execution context; remove underscored variants blocked by RestrictedPython.
  - Updated in-code help text and README to use the new names.
  - Added a regression test that runs through `call_tool_chain` and verifies both helpers are reachable.

- **Dependencies**
  - Bump `code-mode` to `1.1.0` and require `utcp` `>=1.1.2`.

<sup>Written for commit f95e72561689454310d28ff205ce7d022791ed0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

