### PR TITLE
Add utcp cli for with code mode tool execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,34 @@ Works with **any tool ecosystem:**
 npm install @utcp/code-mode
 ```
 
-## Even Easier: Ready-to-Use MCP Server
+## Recommended for shell agents: the `utcp` CLI
 
-**Want Code Mode without any setup?** Use our plug-and-play MCP server with Claude Desktop or any MCP client:
+**If your agent can run shell commands** (Claude Code, Cursor, Codex, Claude Cowork, etc.), the [`utcp` CLI](./code-mode-cli) is the **preferred** way to use Code Mode — no MCP server, no client config, no env vars. The agent self-configures by writing a `.utcp_config.json` and drives everything from the shell.
+
+Just point the agent at the built-in guide:
+
+```bash
+npx -y @utcp/code-mode-cli prompt
+```
+
+Hand it a description of the API to use — a UTCP call template, an **OpenAPI spec**, or a **plain-English description** — and it writes the config, discovers tools, runs tool-chains, and even completes **interactive OAuth logins** (e.g. Notion), all from the shell:
+
+```bash
+npx -y @utcp/code-mode-cli search "<task>"           # discover tools + TS interfaces
+npx -y @utcp/code-mode-cli run <<'EOF'               # run a tool-chain
+const r = await openlibrary.read_search_json_search_json_get({ q: "tolkien", limit: 3 });
+return r.docs.map(b => b.title);
+EOF
+npx -y @utcp/code-mode-cli login <manual>            # interactive OAuth, writes token to .env
+```
+
+> **CLI vs MCP:** prefer the **CLI** whenever the agent has shell access (most coding agents) — it's simpler and self-configuring. Use the **MCP server** (below) only for MCP-only clients like Claude Desktop. Both wrap the same `@utcp/code-mode` engine.
+
+See [`code-mode-cli/`](./code-mode-cli) for full docs.
+
+## Ready-to-Use MCP Server
+
+**On an MCP-only client (e.g. Claude Desktop)?** Use our plug-and-play MCP server. (If your agent has a shell, prefer the [`utcp` CLI](#recommended-for-shell-agents-the-utcp-cli) above.)
 
 ```json
 {

--- a/code-mode-cli/.gitignore
+++ b/code-mode-cli/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.code-mode-login-state.json
+.code-mode-tokens.json

--- a/code-mode-cli/LICENSE
+++ b/code-mode-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Universal Tool Calling Protocol (UTCP)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/code-mode-cli/README.md
+++ b/code-mode-cli/README.md
@@ -1,0 +1,122 @@
+# @utcp/code-mode-cli
+
+**Call any API by writing code — from any shell. No MCP required.**
+
+`utcp` lets an LLM agent discover [UTCP](https://www.utcp.io) tools, run
+TypeScript tool-chains in a sandbox, and complete interactive OAuth logins —
+using only shell commands and a local config file. Built for sandboxed agents
+(e.g. Claude Cowork) that have a shell but no MCP.
+
+## You don't run the CLI yourself
+
+Hand an **agent** a description of the API you want used — **any** of:
+
+- a UTCP **call template** (paste it directly),
+- an **OpenAPI / Swagger spec** (a URL, or a file the agent reads),
+- or just a **plain-English description** of the API (endpoints, base URL, auth).
+
+…and tell it to run:
+
+```bash
+npx -y @utcp/code-mode-cli prompt
+```
+
+That command prints the full self-configuration + usage guide; the agent reads it,
+writes a `.utcp_config.json`, and takes it from there. Everything else below is
+reference.
+
+---
+
+## What the agent does
+
+1. **Configure** — turn your API description into a UTCP manual in `.utcp_config.json`:
+   - call template / OpenAPI URL → an `http` (or `mcp`) manual,
+   - OpenAPI file / plain-English description → write a UTCP manual JSON file and
+     load it with a `file` manual.
+2. **`validate`** — check the config + manuals are well-formed and register.
+3. **`search`** — discover tools and their TypeScript interfaces.
+4. **`run`** — execute a tool-chain (tools are called as `manual.tool({ args })`).
+5. **`login`** — if a tool needs interactive sign-in, complete OAuth (it shows you
+   the URL, you authorize, the token is saved to `.env`).
+
+Every command prints **JSON to stdout** (`login` prints one JSON object per line);
+diagnostics go to stderr, so stdout pipes cleanly into `jq`.
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| `prompt` | Print the full agent guide (read first). |
+| `search <query> [--limit N]` | Find tools; returns name + description + TS interface. |
+| `list` | List all registered tool names. |
+| `info <tool...>` | Print TypeScript interfaces for the named tools. |
+| `keys <tool>` | List required variables (e.g. tokens) for a tool. |
+| `run [code] [-c <code>] [--file <p>] [--timeout <ms>]` | Execute a tool-chain (also reads stdin). |
+| `login <manual> [--paste] [--code <code\|url>]` | Interactive OAuth sign-in; writes the token to `.env`. |
+| `validate [--offline]` | Validate `.utcp_config.json` + its manuals (registers each unless `--offline`). |
+| `validate --manual <file...>` | Validate standalone UTCP manual file(s). |
+| `--help` | Short usage. |
+
+Global: `--config <path>` to use a specific config file (default `./.utcp_config.json`).
+
+## Config example
+
+```json
+{
+  "load_variables_from": [
+    { "variable_loader_type": "dotenv", "env_file_path": ".env" }
+  ],
+  "manual_call_templates": [
+    {
+      "name": "openlibrary",
+      "call_template_type": "http",
+      "http_method": "GET",
+      "url": "https://openlibrary.org/static/openapi.json",
+      "content_type": "application/json"
+    }
+  ]
+}
+```
+
+## Interactive OAuth (`oauth2_user`)
+
+Declare an `oauth2_user` auth block; the token is provisioned by `utcp login`
+and injected on every call afterwards (UTCP never runs the flow itself).
+
+- **Remote MCP server (e.g. Notion):** minimal block — endpoints auto-discovered
+  via the MCP SDK (discovery + dynamic client registration + PKCE):
+  ```json
+  "auth": { "auth_type": "oauth2_user", "access_token": "${NOTION_TOKEN}" }
+  ```
+  `utcp login notion` prints a sign-in URL; the user authorizes and pastes the
+  redirect URL back via `--code`.
+- **HTTP API with a device-code flow:** declare `device_authorization_endpoint`,
+  `token_endpoint`, `client_id`, `scope`; `utcp login <manual>` prints a URL +
+  code and polls until done.
+
+Tokens are written to the `dotenv` file (default `.env`), keyed by the namespaced
+variable UTCP looks up (`<manual>_<VAR>`), so the `dotenv` loader block is required
+when using `${VAR}` secrets or `oauth2_user`.
+
+> **Security:** the bundled `@utcp/cli` plugin lets a manual run arbitrary local
+> commands. Only register manuals from sources you trust.
+
+## Prerequisites
+
+- Node.js ≥ 18.
+- `isolated-vm` is a native addon; on Windows it needs the Visual Studio C++ build
+  tools / `node-gyp` toolchain.
+
+## Local development
+
+Lives in the [code-mode](https://github.com/universal-tool-calling-protocol/code-mode)
+repo alongside `typescript-library` (the `@utcp/code-mode` engine) and
+`code-mode-mcp` (the MCP bridge). Depends on published `@utcp/*` (`@utcp/sdk`
+≥ 1.1.1, `@utcp/http` ≥ 1.1.7, `@utcp/mcp` ≥ 1.1.3 — the ones carrying the
+`oauth2_user` variant).
+
+```bash
+npm install
+npm run build
+node dist/index.js --help
+```

--- a/code-mode-cli/SKILL.md
+++ b/code-mode-cli/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: utcp-cli
+description: >
+  Call external APIs, MCP servers, and CLI tools by writing TypeScript code that
+  runs in a sandbox — without MCP. Use when the user wants the agent to use a
+  tool/API/integration (e.g. "search Open Library", "read my Notion", "call this
+  REST API") in an environment that has a shell but no MCP config and no
+  settable environment variables (e.g. Claude Cowork sandboxes). Self-configure
+  by writing a .utcp_config.json file, discover tools with `utcp search`,
+  run tool-chains with `utcp run`, and complete interactive OAuth sign-ins
+  with `utcp login`. Bootstrap with `npx @utcp/code-mode-cli prompt`.
+---
+
+# utcp cli
+
+`utcp` (npm: `@utcp/code-mode-cli`) lets you call [UTCP](https://www.utcp.io)
+tools by writing TypeScript that executes in an isolated sandbox. It needs only a
+shell and a working folder — no MCP, no environment variables.
+
+Run everything via `npx @utcp/code-mode-cli <command>` (or `utcp <command>`
+if installed). **All output is JSON on stdout.**
+
+## 1. Read the guide
+
+```bash
+npx @utcp/code-mode-cli prompt
+```
+
+## 2. Configure (write a file — no env vars)
+
+Write `.utcp_config.json` in the working directory listing the manuals (APIs /
+MCP servers / CLIs) you need:
+
+```json
+{
+  "load_variables_from": [
+    { "variable_loader_type": "dotenv", "env_file_path": ".env" }
+  ],
+  "manual_call_templates": [
+    {
+      "name": "openlibrary",
+      "call_template_type": "http",
+      "http_method": "GET",
+      "url": "https://openlibrary.org/static/openapi.json",
+      "content_type": "application/json"
+    }
+  ]
+}
+```
+
+Transports: `http` (incl. OpenAPI URLs), `mcp` (remote/local MCP servers), `cli`,
+`text`, `file`.
+
+## 3. Discover
+
+```bash
+utcp search "search for books"   # returns tools + TypeScript interfaces
+utcp list                        # all tool names
+utcp info <tool>                 # full interface for a tool
+utcp keys <tool>                 # required variables (tokens) for a tool
+```
+
+## 4. Run a tool-chain
+
+Call tools as `manual.tool({ args })`. Top-level `await` and `return` work.
+Use a heredoc for multi-line code:
+
+```bash
+utcp run <<'EOF'
+const r = await openlibrary.read_search_json_search_json_get({ q: "tolkien", limit: 3 });
+return (r.docs || []).map(b => b.title);
+EOF
+```
+
+Output: `{"success":true,"result":<value>,"logs":[...]}`.
+
+## 5. Interactive OAuth (user signs into a page)
+
+Declare an `oauth2_user` auth block on the manual. For a remote MCP server the
+block is just `{ "auth_type": "oauth2_user", "access_token": "${MY_TOKEN}" }` —
+endpoints are auto-discovered. Then:
+
+```bash
+utcp login <manual>
+```
+
+`login` prints NDJSON describing what to do next. Handle it like this:
+
+- **`{"action":"show_user_url","then":"poll", ...}`** (device flow): show the
+  user the `url` and `user_code` in chat, then wait — the command polls and
+  finishes on its own, printing `{"action":"done", ...}`.
+- **`{"action":"show_user_url","then":"rerun_with_code","next":"...", ...}`**
+  (paste flow, used by MCP / authorization-code): show the user the `url`. After
+  they sign in they are redirected to a URL that won't load (e.g.
+  `http://localhost:8765/callback?code=...`). Ask them to copy that full
+  address-bar URL and paste it to you, then run:
+  ```bash
+  utcp login <manual> --code "<pasted url or code>"
+  ```
+  It writes the token to `.env`; tools are now authenticated.
+
+## Failure modes
+
+- **`Invalid CallTemplate object`** → a manual in `.utcp_config.json` is missing a
+  required field or uses an unknown `call_template_type`. Re-check against the
+  schema (`utcp prompt`).
+- **`access_token ... is empty` / `keys` shows a missing variable** → run
+  `utcp login <manual>`.
+- **`No pending login for '<manual>'`** → run `utcp login <manual>` (without
+  `--code`) first to start the flow.
+- **`isolated-vm` install fails on Windows** → needs the VS C++ build tools.
+
+## Boundaries
+
+- The bundled `@utcp/cli` plugin can run arbitrary local commands — only register
+  manuals from trusted sources.
+- This is for shell/sandbox agents. On an MCP client, use `@utcp/code-mode-mcp`.

--- a/code-mode-cli/index.ts
+++ b/code-mode-cli/index.ts
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+// @utcp/code-mode-cli — call UTCP tools via code mode from any shell.
+//
+// Output contract: every command prints JSON to stdout. Most print a single
+// object; `login` prints NDJSON (one object per line). Errors print
+// {"error": "..."} and exit non-zero. Human/diagnostic noise goes to stderr.
+import { promises as fs } from 'fs';
+import path from 'path';
+import util from 'util';
+
+// Keep stdout reserved for machine-readable JSON: route UTCP's diagnostic
+// console output (log/info/warn) to stderr. Tool-chain console output is
+// captured separately by callToolChain and returned in `logs`.
+console.log = (...args: any[]) => process.stderr.write(util.format(...args) + '\n');
+console.info = (...args: any[]) => process.stderr.write(util.format(...args) + '\n');
+console.warn = (...args: any[]) => process.stderr.write(util.format(...args) + '\n');
+
+// Protocol plugins register themselves on import (side effects).
+import '@utcp/http';
+import '@utcp/text';
+import '@utcp/mcp';
+import '@utcp/cli';
+import '@utcp/dotenv-loader';
+import '@utcp/file';
+
+import { CodeModeUtcpClient } from '@utcp/code-mode';
+import { createClient, resolveConfigPath } from './src/config.js';
+import { utcpNameToTsInterfaceName, findToolByName } from './src/names.js';
+import {
+  httpDeviceLogin,
+  httpAuthCodeStart,
+  mcpLoginStart,
+  loginFinishWithCode,
+  DEFAULT_REDIRECT,
+} from './src/oauth.js';
+import { validateConfig, validateManualFiles } from './src/validate.js';
+
+// ---------------------------------------------------------------------------
+// arg parsing
+// ---------------------------------------------------------------------------
+
+interface Args {
+  command: string;
+  positionals: string[];
+  config?: string;
+  limit?: number;
+  code?: string;
+  file?: string;
+  timeout?: number;
+  paste: boolean;
+  authCode?: string;
+  offline: boolean;
+  manualMode: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const a: Args = { command: argv[0] || 'help', positionals: [], paste: false, offline: false, manualMode: false };
+  for (let i = 1; i < argv.length; i++) {
+    const t = argv[i];
+    switch (t) {
+      case '--config': a.config = argv[++i]; break;
+      case '--limit': a.limit = Number(argv[++i]); break;
+      case '-c': case '--code-string': a.code = argv[++i]; break;
+      case '--file': a.file = argv[++i]; break;
+      case '--timeout': a.timeout = Number(argv[++i]); break;
+      case '--paste': a.paste = true; break;
+      case '--code': a.authCode = argv[++i]; break;
+      case '--offline': a.offline = true; break;
+      case '--manual': a.manualMode = true; break;
+      case '-h': case '--help': a.command = a.command === 'help' ? 'help' : a.command; a.positionals.push('--help'); break;
+      default: a.positionals.push(t);
+    }
+  }
+  return a;
+}
+
+function out(obj: unknown): void {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+function fail(message: string): never {
+  process.stdout.write(JSON.stringify({ error: message }) + '\n');
+  process.exit(1);
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return '';
+  const chunks: Buffer[] = [];
+  for await (const c of process.stdin) chunks.push(c as Buffer);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// guide text
+// ---------------------------------------------------------------------------
+
+const SELF_CONFIG_GUIDE = `
+## Self-configuration (no environment variables needed)
+
+You configure tools by writing a \`.utcp_config.json\` file in your working
+directory, then running \`utcp\` against it. Minimal example:
+
+{
+  "load_variables_from": [
+    { "variable_loader_type": "dotenv", "env_file_path": ".env" }
+  ],
+  "manual_call_templates": [
+    {
+      "name": "openlibrary",
+      "call_template_type": "http",
+      "http_method": "GET",
+      "url": "https://openlibrary.org/static/openapi.json",
+      "content_type": "application/json"
+    }
+  ]
+}
+
+### Workflow
+1. Write \`.utcp_config.json\` with the manuals (APIs / MCP servers / CLIs) you need.
+2. \`utcp validate\` to confirm the config + manuals are well-formed and that
+   each manual registers (use \`--offline\` to skip the network and only check shape).
+3. \`utcp search "<task>"\` to discover tools + their TypeScript interfaces.
+4. Write a tool-chain in TypeScript and run it:
+   utcp run <<'EOF'
+   const r = await openlibrary.read_search_json({ q: "tolkien" });
+   return r.docs.slice(0, 3).map(b => b.title);
+   EOF
+5. Tools are called as \`manual.tool({ args })\`. Top-level \`await\` and \`return\` work.
+
+### You can load an API from any description — not just a UTCP call template
+- **OpenAPI / Swagger spec (URL):** use an \`http\` manual whose \`url\` points at the
+  spec; UTCP auto-converts it to tools. (The openlibrary example above is exactly this.)
+- **OpenAPI spec you have as a file, OR a natural-language API description:** YOU
+  write a UTCP manual JSON file (a \`{ "utcp_version": "...", "tools": [...] }\`
+  document — each tool has name/description/inputs/outputs/tool_call_template),
+  then load it with a \`file\` manual:
+    { "name": "myapi", "call_template_type": "file", "file_path": "./myapi_manual.json" }
+  Validate the manual you wrote first:  \`utcp validate --manual ./myapi_manual.json\`
+- When unsure of the manual schema, run \`utcp validate --manual <file>\` and fix
+  the reported errors until it passes; then add the \`file\` manual to your config and
+  \`utcp validate\` the whole config.
+
+### Authentication
+- API key / basic / OAuth2 client-credentials: put values (or \`\${VAR}\` refs) in the
+  manual's \`auth\` block; provide \`\${VAR}\` values via the \`.env\` dotenv loader.
+- Interactive sign-in (user opens a page): declare an \`oauth2_user\` auth block:
+    "auth": { "auth_type": "oauth2_user", "access_token": "\${MY_TOKEN}",
+              "grant_type": "device_code",
+              "device_authorization_endpoint": "...", "token_endpoint": "...",
+              "client_id": "..." , "scope": "..." }
+  For MCP servers, only \`{ "auth_type": "oauth2_user", "access_token": "\${MY_TOKEN}" }\`
+  is needed — endpoints are auto-discovered. Then run:
+    utcp login <manual>
+  and follow the printed instructions (show the user the URL). \`login\` writes the
+  token into \`.env\`; UTCP injects it on every call afterwards.
+`.trim();
+
+function helpText(): string {
+  return [
+    'utcp — call UTCP tools via code mode from any shell. No MCP required.',
+    '',
+    'Commands:',
+    '  prompt                      Print the full agent guide (read this first).',
+    '  search <query> [--limit N]  Find tools; returns TypeScript interfaces.',
+    '  list                        List all registered tool names.',
+    '  info <tool...>              Print TypeScript interfaces for tools.',
+    '  keys <tool>                 List required variables (e.g. tokens) for a tool.',
+    '  run [code] [-c <code>] [--file <p>] [--timeout <ms>]',
+    '                              Execute a TS tool-chain (also reads stdin).',
+    '  login <manual> [--paste] [--code <code|url>]',
+    '                              Interactive OAuth sign-in; writes token to .env.',
+    '  validate [--offline]        Validate .utcp_config.json + its manuals.',
+    '  validate --manual <file...> Validate standalone UTCP manual file(s).',
+    '',
+    'Global: --config <path>   Use a specific .utcp_config.json',
+    '',
+    'Run `utcp prompt` for the full self-configuration + login guide.',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// login helpers
+// ---------------------------------------------------------------------------
+
+/** Re-derives the namespaced dotenv key UTCP looks up for `${var}` in a manual. */
+function namespacedKey(manualName: string, varName: string): string {
+  return manualName.replace(/_/g, '!').replace(/!/g, '__') + '_' + varName;
+}
+
+function varNameFromTemplate(accessToken: string): string | null {
+  const m = /\$\{?([a-zA-Z0-9_]+)\}?/.exec(accessToken || '');
+  return m ? m[1]! : null;
+}
+
+async function readRawConfig(configPath: string): Promise<any> {
+  try {
+    return JSON.parse(await fs.readFile(configPath, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function dotenvPath(rawConfig: any): string {
+  const loaders: any[] = rawConfig.load_variables_from || [];
+  const dotenv = loaders.find((l) => l && l.variable_loader_type === 'dotenv');
+  const rel = dotenv?.env_file_path || '.env';
+  // The dotenv loader resolves env_file_path relative to process.cwd().
+  return path.resolve(process.cwd(), rel);
+}
+
+async function handleLogin(args: Args): Promise<void> {
+  const target = args.positionals[0];
+  if (!target) fail('Usage: utcp login <manual> [--paste] [--code <code|url>]');
+  const manual = target.includes('.') ? target.split('.')[0]! : target;
+
+  // Step 2 of any paste flow: just exchange the code.
+  if (args.authCode) {
+    await loginFinishWithCode(manual, args.authCode);
+    return;
+  }
+
+  const configPath = await resolveConfigPath(args.config);
+  const raw = await readRawConfig(configPath);
+  const entry = (raw.manual_call_templates || []).find((m: any) => m.name === manual);
+  if (!entry) fail(`Manual '${manual}' not found in ${configPath}.`);
+  const auth = entry.auth || {};
+  if (auth.auth_type !== 'oauth2_user') {
+    fail(`Manual '${manual}' does not declare an 'oauth2_user' auth block; nothing to log in to.`);
+  }
+  const varName = varNameFromTemplate(auth.access_token);
+  if (!varName) fail(`Manual '${manual}' oauth2_user.access_token must reference a variable like "\${MY_TOKEN}".`);
+  const envKey = namespacedKey(manual, varName!);
+  const envPath = dotenvPath(raw);
+  const redirect = auth.redirect_uri || DEFAULT_REDIRECT;
+
+  if (entry.call_template_type === 'mcp') {
+    const servers = entry.config?.mcpServers || {};
+    const first: any = Object.values(servers)[0];
+    const serverUrl = first?.url;
+    if (!serverUrl) fail(`MCP manual '${manual}' has no http server url to discover OAuth from.`);
+    await mcpLoginStart({ manual, serverUrl, scope: auth.scope, redirect, envPath, envKey });
+    return;
+  }
+
+  // HTTP manual: choose flow.
+  const grant = args.paste
+    ? 'authorization_code'
+    : auth.grant_type || (auth.device_authorization_endpoint ? 'device_code' : 'authorization_code');
+
+  if (grant === 'device_code') {
+    if (!auth.device_authorization_endpoint || !auth.token_endpoint || !auth.client_id) {
+      fail(`device_code flow needs device_authorization_endpoint, token_endpoint and client_id in the oauth2_user block.`);
+    }
+    await httpDeviceLogin({
+      manual,
+      deviceEndpoint: auth.device_authorization_endpoint,
+      tokenEndpoint: auth.token_endpoint,
+      clientId: auth.client_id,
+      scope: auth.scope,
+      envPath,
+      envKey,
+    });
+  } else {
+    if (!auth.authorization_endpoint || !auth.token_endpoint || !auth.client_id) {
+      fail(`authorization_code flow needs authorization_endpoint, token_endpoint and client_id in the oauth2_user block.`);
+    }
+    await httpAuthCodeStart({
+      manual,
+      authEndpoint: auth.authorization_endpoint,
+      tokenEndpoint: auth.token_endpoint,
+      clientId: auth.client_id,
+      scope: auth.scope,
+      redirect,
+      envPath,
+      envKey,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (['help', '--help', '-h'].includes(args.command) || args.positionals.includes('--help')) {
+    process.stdout.write(helpText() + '\n');
+    return;
+  }
+
+  if (args.command === 'prompt') {
+    process.stdout.write(
+      CodeModeUtcpClient.AGENT_PROMPT_TEMPLATE + '\n\n' + SELF_CONFIG_GUIDE + '\n',
+    );
+    return;
+  }
+
+  if (args.command === 'login') {
+    await handleLogin(args);
+    return;
+  }
+
+  if (args.command === 'validate') {
+    if (args.manualMode) {
+      if (args.positionals.length === 0) fail('Usage: utcp validate --manual <file...>');
+      out(await validateManualFiles(args.positionals));
+    } else {
+      out(await validateConfig(args.config, args.offline));
+    }
+    return;
+  }
+
+  // All remaining commands need a client.
+  const { client } = await createClient(args.config);
+
+  switch (args.command) {
+    case 'search': {
+      const query = args.positionals.join(' ');
+      if (!query) fail('Usage: utcp search <query> [--limit N]');
+      const tools = await client.searchTools(query, args.limit ?? 10);
+      out({
+        tools: tools.map((t) => ({
+          name: utcpNameToTsInterfaceName(t.name),
+          description: t.description,
+          typescript_interface: client.toolToTypeScriptInterface(t),
+        })),
+      });
+      break;
+    }
+    case 'list': {
+      const tools = await client.config.tool_repository.getTools();
+      out({ tools: tools.map((t) => utcpNameToTsInterfaceName(t.name)) });
+      break;
+    }
+    case 'info': {
+      if (args.positionals.length === 0) fail('Usage: utcp info <tool...>');
+      const parts: string[] = [];
+      for (const name of args.positionals) {
+        const found = await findToolByName(client, name);
+        parts.push(found ? client.toolToTypeScriptInterface(found.tool) : `// Tool '${name}' not found`);
+      }
+      out({ interfaces: parts.join('\n\n') });
+      break;
+    }
+    case 'keys': {
+      const name = args.positionals[0];
+      if (!name) fail('Usage: utcp keys <tool>');
+      const found = await findToolByName(client, name);
+      if (!found) fail(`Tool '${name}' not found`);
+      const vars = await client.getRequiredVariablesForRegisteredTool(found!.utcpName);
+      out({ tool: name, required_variables: vars });
+      break;
+    }
+    case 'run': {
+      let code = args.code ?? '';
+      if (!code && args.file) code = await fs.readFile(args.file, 'utf-8');
+      if (!code && args.positionals.length) code = args.positionals.join(' ');
+      if (!code) code = await readStdin();
+      if (!code.trim()) fail('No code provided. Pass via -c, --file, a positional, or stdin.');
+      const { result, logs } = await client.callToolChain(code, args.timeout ?? 30000);
+      out({ success: true, result, logs });
+      break;
+    }
+    default:
+      fail(`Unknown command '${args.command}'. Run \`utcp help\`.`);
+  }
+
+  await client.close().catch(() => {});
+}
+
+main().catch((e) => {
+  fail(e instanceof Error ? e.message : String(e));
+});

--- a/code-mode-cli/package-lock.json
+++ b/code-mode-cli/package-lock.json
@@ -1,0 +1,1603 @@
+{
+  "name": "@utcp/code-mode-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@utcp/code-mode-cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.4",
+        "@utcp/cli": "^1.1.1",
+        "@utcp/code-mode": "^1.2.12",
+        "@utcp/dotenv-loader": "^1.1.0",
+        "@utcp/file": "^1.1.0",
+        "@utcp/http": "^1.1.7",
+        "@utcp/mcp": "^1.1.3",
+        "@utcp/sdk": "^1.1.1",
+        "@utcp/text": "^1.1.0",
+        "dotenv": "^16.0.0",
+        "isolated-vm": "^6.0.0"
+      },
+      "bin": {
+        "code-mode": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "15.3.6",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.3.6.tgz",
+      "integrity": "sha512-oPFDSviRrreUmCZn09LCD4S9QQa6j7zfEwBM1pkGa/kXY0O4sXsEXn4emLP/Tt6tik2+BtgwKk2eldAeOWZ2Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/json-schema": "^7.0.15"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@utcp/cli": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@utcp/cli/-/cli-1.1.1.tgz",
+      "integrity": "sha512-otaArdHr16WgsWcDEi1ftvPcm5Pdytp04XBANXsXYSTb7ZMLBQjKcqJibPcP+ncXU6Qgm6FSnqVao3Sw+GqvXg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@utcp/sdk": "^1.1.0"
+      }
+    },
+    "node_modules/@utcp/code-mode": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@utcp/code-mode/-/code-mode-1.2.12.tgz",
+      "integrity": "sha512-LnqLrrQfIVVGl2s5poF72CiN217UDcqpGK12oteEg6kI4eYK53sCg66Y6fp59oq6TvJl22QMR5xmjHBY1KrahQ==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@utcp/sdk": "^1.1.0",
+        "isolated-vm": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "isolated-vm": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@utcp/dotenv-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@utcp/dotenv-loader/-/dotenv-loader-1.1.0.tgz",
+      "integrity": "sha512-kgziyumoeWVnCBtcQ59VJEDJXE/M/Or62TPamBVGVpyvNWyz4xH0CjLsN+k95I8NElZma45s4jgWoQrUMB6ARw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "dotenv": "^17.2.1",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "@utcp/sdk": "^1.1.0"
+      }
+    },
+    "node_modules/@utcp/dotenv-loader/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@utcp/dotenv-loader/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@utcp/file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@utcp/file/-/file-1.1.0.tgz",
+      "integrity": "sha512-7bx1KoYEWEaXZvwbzOfePByL1NKTGAvO2cuXOYItKB8XCHRUDzcPEZkEPgKJqavBgYNJXVEiNQJlf7WRWJGIeQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@utcp/http": "^1.1.0",
+        "@utcp/sdk": "^1.1.0",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@utcp/http": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@utcp/http/-/http-1.1.7.tgz",
+      "integrity": "sha512-xCSjczU3C8N4bZzch8YSe0Bnv5gaDh1rnZCE3sSZwZRmvUGPxKfEN4esDks/JfXWolSfS55EXUKJsT72CnUI2g==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@utcp/sdk": "^1.1.1",
+        "axios": "^1.11.0",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@utcp/mcp": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@utcp/mcp/-/mcp-1.1.3.tgz",
+      "integrity": "sha512-+3E2n5GJrzJejIWgWarQifL8DJOtFcTr0gWd+4Y3kiih7VrrZdW/437UzgKanwTCUIEwT/w8HI8yL8c0t/yomg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^15.1.2",
+        "@modelcontextprotocol/sdk": "^1.17.4",
+        "@utcp/sdk": "^1.1.1",
+        "axios": "^1.11.0"
+      }
+    },
+    "node_modules/@utcp/sdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@utcp/sdk/-/sdk-1.1.1.tgz",
+      "integrity": "sha512-TDvzYRbeBrto04NPM8jX+xzBj23reRaanmtxnQK1ReRJRJ4UiYF5aSy8lk+baTwIWwxVZejUUHY8EyQHj+Olrg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "dotenv": "^17.2.1",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@utcp/sdk/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@utcp/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@utcp/text": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@utcp/text/-/text-1.1.0.tgz",
+      "integrity": "sha512-hAcnvfxW8HjapWEP1es2XvkuYriV2uJWXd7fQl8UNg/4hEeJbJwBWwbNkst/i9ZmTBkHcCr7vSMAtj1CeTlcjg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@utcp/http": "^1.1.0",
+        "@utcp/sdk": "^1.1.0",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/isolated-vm": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
+      "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/code-mode-cli/package.json
+++ b/code-mode-cli/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@utcp/code-mode-cli",
+  "version": "0.1.0",
+  "description": "Shell CLI that lets ANY LLM agent call UTCP tools via code mode — discover tools, run TypeScript tool-chains in a sandbox, and complete interactive OAuth logins. No MCP required. Built for sandboxed agents (e.g. Claude Cowork).",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "utcp": "./dist/index.js"
+  },
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "SKILL.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build",
+    "start": "node dist/index.js"
+  },
+  "keywords": [
+    "utcp",
+    "code-mode",
+    "cli",
+    "llm",
+    "agent",
+    "tool-calling",
+    "oauth",
+    "sandbox",
+    "cowork"
+  ],
+  "author": "UTCP Team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/universal-tool-calling-protocol/code-mode.git",
+    "directory": "code-mode-cli"
+  },
+  "homepage": "https://github.com/universal-tool-calling-protocol/code-mode/tree/main/code-mode-cli#readme",
+  "bugs": {
+    "url": "https://github.com/universal-tool-calling-protocol/code-mode/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@utcp/sdk": "^1.1.1",
+    "@utcp/http": "^1.1.7",
+    "@utcp/mcp": "^1.1.3",
+    "@utcp/cli": "^1.1.1",
+    "@utcp/text": "^1.1.0",
+    "@utcp/file": "^1.1.0",
+    "@utcp/dotenv-loader": "^1.1.0",
+    "@utcp/code-mode": "^1.2.12",
+    "@modelcontextprotocol/sdk": "^1.17.4",
+    "isolated-vm": "^6.0.0",
+    "dotenv": "^16.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/code-mode-cli/package.json
+++ b/code-mode-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/code-mode-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shell CLI that lets ANY LLM agent call UTCP tools via code mode — discover tools, run TypeScript tool-chains in a sandbox, and complete interactive OAuth logins. No MCP required. Built for sandboxed agents (e.g. Claude Cowork).",
   "type": "module",
   "main": "dist/index.js",

--- a/code-mode-cli/src/config.ts
+++ b/code-mode-cli/src/config.ts
@@ -1,0 +1,75 @@
+// Config discovery + client construction.
+// Adapted from the code-mode MCP bridge's initializeUtcpClient(), but driven by
+// a CLI flag instead of only an env var, since sandboxed agents (e.g. Cowork)
+// cannot set environment variables — they write a local .utcp_config.json.
+import path from 'path';
+import { promises as fs } from 'fs';
+import { UtcpClientConfigSerializer, ensureCorePluginsInitialized } from '@utcp/sdk';
+import { CodeModeUtcpClient } from '@utcp/code-mode';
+
+export interface ResolvedClient {
+  client: CodeModeUtcpClient;
+  /** Absolute path to the config file that was (or would be) loaded. */
+  configPath: string;
+  /** Directory the client resolves relative paths and secrets (.env) against. */
+  scriptDir: string;
+  /** The raw, un-substituted config object as read from disk. */
+  rawConfig: Record<string, unknown>;
+}
+
+export interface CreateClientOptions {
+  /** When true, do not register the config's manuals on create (caller registers them). */
+  skipManualRegistration?: boolean;
+}
+
+/**
+ * Resolves the config path with precedence:
+ *   1. explicit --config flag
+ *   2. ./.utcp_config.json in the current working directory
+ *   3. UTCP_CONFIG_FILE environment variable
+ * Falls back to cwd/.utcp_config.json (which may not exist → empty config).
+ */
+export async function resolveConfigPath(configFlag?: string): Promise<string> {
+  if (configFlag) return path.resolve(configFlag);
+
+  const cwdConfig = path.resolve(process.cwd(), '.utcp_config.json');
+  try {
+    await fs.access(cwdConfig);
+    return cwdConfig;
+  } catch {
+    /* fall through */
+  }
+
+  if (process.env.UTCP_CONFIG_FILE) return path.resolve(process.env.UTCP_CONFIG_FILE);
+  return cwdConfig;
+}
+
+/** Builds a CodeModeUtcpClient from the resolved config file. */
+export async function createClient(
+  configFlag?: string,
+  opts: CreateClientOptions = {},
+): Promise<ResolvedClient> {
+  ensureCorePluginsInitialized();
+
+  const configPath = await resolveConfigPath(configFlag);
+  const scriptDir = path.dirname(configPath);
+
+  let rawConfig: Record<string, unknown> = {};
+  try {
+    rawConfig = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+  } catch (e: any) {
+    if (e.code !== 'ENOENT') {
+      // Surface parse errors to stderr; an empty config still lets `prompt`/`--help` work.
+      process.stderr.write(`[code-mode] Could not read/parse ${configPath}: ${e.message}\n`);
+    }
+  }
+
+  // Validate (and optionally strip manuals so the caller can register them
+  // one-by-one and capture per-manual results).
+  const configForClient = opts.skipManualRegistration
+    ? { ...rawConfig, manual_call_templates: [] }
+    : rawConfig;
+  const clientConfig = new UtcpClientConfigSerializer().validateDict(configForClient);
+  const client = await CodeModeUtcpClient.create(scriptDir, clientConfig);
+  return { client, configPath, scriptDir, rawConfig };
+}

--- a/code-mode-cli/src/names.ts
+++ b/code-mode-cli/src/names.ts
@@ -1,0 +1,38 @@
+// Tool-name helpers. Mirrors the mapping used by the code-mode MCP bridge so the
+// CLI surfaces tools to the agent under the same TypeScript-interface names that
+// `callToolChain` exposes (e.g. manual.tool).
+import type { CodeModeUtcpClient } from '@utcp/code-mode';
+import type { Tool } from '@utcp/sdk';
+
+/** Sanitizes a name into a valid TypeScript identifier. */
+export function sanitizeIdentifier(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^[0-9]/, '_$&');
+}
+
+/** Converts a UTCP tool name ("manual.tool") to its TS interface name. */
+export function utcpNameToTsInterfaceName(utcpName: string): string {
+  if (utcpName.includes('.')) {
+    const parts = utcpName.split('.');
+    const manualName = parts[0]!;
+    const toolParts = parts.slice(1);
+    return `${sanitizeIdentifier(manualName)}.${toolParts.map(sanitizeIdentifier).join('_')}`;
+  }
+  return sanitizeIdentifier(utcpName);
+}
+
+/** Finds a tool by either its UTCP name or its TS-interface name. */
+export async function findToolByName(
+  client: CodeModeUtcpClient,
+  name: string,
+): Promise<{ tool: Tool; utcpName: string } | null> {
+  const direct = await client.config.tool_repository.getTool(name);
+  if (direct) return { tool: direct, utcpName: name };
+
+  const all = await client.config.tool_repository.getTools();
+  for (const tool of all) {
+    if (utcpNameToTsInterfaceName(tool.name) === name) {
+      return { tool, utcpName: tool.name };
+    }
+  }
+  return null;
+}

--- a/code-mode-cli/src/oauth.ts
+++ b/code-mode-cli/src/oauth.ts
@@ -1,0 +1,344 @@
+// Interactive OAuth login flows for `utcp login`.
+//
+// UTCP cannot run interactive OAuth itself (no user channel, no persistence), so
+// this module performs the sign-in and writes the resulting bearer token into a
+// dotenv file. A manual's `oauth2_user` auth block then references that token via
+// `access_token: "${VAR}"`, and UTCP injects it at call time.
+//
+// Two transport shapes:
+//   - Generic HTTP manuals: endpoints come from the auth block. Device-code flow
+//     is a single streaming command; authorization-code is a two-step paste flow.
+//   - MCP manuals: endpoints are DISCOVERED from the server via the MCP SDK
+//     (RFC 9728 + RFC 8414), with dynamic client registration (RFC 7591) and a
+//     two-step PKCE paste flow.
+//
+// All output is NDJSON: one JSON object per line. Device-flow prints the sign-in
+// line immediately, then a result line once authorized.
+import crypto from 'crypto';
+import path from 'path';
+import { promises as fs } from 'fs';
+import {
+  discoverOAuthProtectedResourceMetadata,
+  discoverAuthorizationServerMetadata,
+  registerClient,
+  startAuthorization,
+  exchangeAuthorization,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+
+const STATE_FILE = '.code-mode-login-state.json';
+const TOKENS_FILE = '.code-mode-tokens.json';
+/** Loopback redirect: the browser lands here after sign-in; the URL bar holds ?code=. */
+export const DEFAULT_REDIRECT = 'http://localhost:8765/callback';
+
+function emit(obj: unknown): void {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// dotenv + state persistence
+// ---------------------------------------------------------------------------
+
+/** Sets or replaces `key=value` in a dotenv file (created if missing). */
+export async function upsertEnvVar(envPath: string, key: string, value: string): Promise<void> {
+  let lines: string[] = [];
+  try {
+    const existing = await fs.readFile(envPath, 'utf-8');
+    lines = existing.split(/\r?\n/).filter((l) => l.trim() !== '' && !l.startsWith(`${key}=`));
+  } catch (e: any) {
+    if (e.code !== 'ENOENT') throw e;
+  }
+  lines.push(`${key}=${value}`);
+  await fs.writeFile(envPath, lines.join('\n') + '\n', 'utf-8');
+}
+
+type LoginState = Record<string, any>;
+
+async function readStateMap(): Promise<Record<string, LoginState>> {
+  try {
+    return JSON.parse(await fs.readFile(path.resolve(process.cwd(), STATE_FILE), 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+async function saveState(manual: string, state: LoginState): Promise<void> {
+  const map = await readStateMap();
+  map[manual] = state;
+  await fs.writeFile(path.resolve(process.cwd(), STATE_FILE), JSON.stringify(map, null, 2), 'utf-8');
+}
+
+async function loadState(manual: string): Promise<LoginState | null> {
+  const map = await readStateMap();
+  return map[manual] ?? null;
+}
+
+async function clearState(manual: string): Promise<void> {
+  const map = await readStateMap();
+  delete map[manual];
+  await fs.writeFile(path.resolve(process.cwd(), STATE_FILE), JSON.stringify(map, null, 2), 'utf-8');
+}
+
+async function persistTokenMeta(manual: string, meta: Record<string, any>): Promise<void> {
+  let map: Record<string, any> = {};
+  try {
+    map = JSON.parse(await fs.readFile(path.resolve(process.cwd(), TOKENS_FILE), 'utf-8'));
+  } catch {
+    /* new file */
+  }
+  map[manual] = { ...(map[manual] || {}), ...meta };
+  await fs.writeFile(path.resolve(process.cwd(), TOKENS_FILE), JSON.stringify(map, null, 2), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/** Accepts a bare code or a full pasted redirect URL and returns the code. */
+export function parseCodeFromInput(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed.includes('://') || trimmed.includes('?')) {
+    try {
+      const url = new URL(trimmed.includes('://') ? trimmed : `http://x/${trimmed}`);
+      const code = url.searchParams.get('code');
+      if (code) return code;
+    } catch {
+      /* not a URL, treat as raw code */
+    }
+  }
+  return trimmed;
+}
+
+function b64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function postForm(url: string, params: Record<string, string>): Promise<any> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+    body: new URLSearchParams(params).toString(),
+  });
+  const text = await res.text();
+  let json: any;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = { raw: text };
+  }
+  return { ok: res.ok, status: res.status, json };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// Generic HTTP — device-code flow (single streaming command)
+// ---------------------------------------------------------------------------
+
+export interface HttpDeviceArgs {
+  manual: string;
+  deviceEndpoint: string;
+  tokenEndpoint: string;
+  clientId: string;
+  scope?: string;
+  envPath: string;
+  envKey: string;
+}
+
+export async function httpDeviceLogin(a: HttpDeviceArgs): Promise<void> {
+  const start = await postForm(a.deviceEndpoint, {
+    client_id: a.clientId,
+    ...(a.scope ? { scope: a.scope } : {}),
+  });
+  if (!start.ok || !start.json.device_code) {
+    throw new Error(`Device authorization failed (${start.status}): ${JSON.stringify(start.json)}`);
+  }
+  const d = start.json;
+  // Print the sign-in instruction immediately so the agent can relay it.
+  emit({
+    action: 'show_user_url',
+    url: d.verification_uri,
+    user_code: d.user_code,
+    verification_uri_complete: d.verification_uri_complete,
+    then: 'poll',
+    message: `Tell the user to open ${d.verification_uri} and enter code ${d.user_code}. Polling for completion...`,
+  });
+
+  let interval = (d.interval || 5) * 1000;
+  const deadline = Date.now() + (d.expires_in || 900) * 1000;
+  while (Date.now() < deadline) {
+    await sleep(interval);
+    const poll = await postForm(a.tokenEndpoint, {
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      device_code: d.device_code,
+      client_id: a.clientId,
+    });
+    if (poll.json.access_token) {
+      await upsertEnvVar(a.envPath, a.envKey, poll.json.access_token);
+      if (poll.json.refresh_token) {
+        await persistTokenMeta(a.manual, { refresh_token: poll.json.refresh_token, client_id: a.clientId });
+      }
+      emit({ action: 'done', wrote: a.envKey, env_file: a.envPath, message: 'Login complete. The token is now available to the manual.' });
+      return;
+    }
+    const err = poll.json.error;
+    if (err === 'authorization_pending') continue;
+    if (err === 'slow_down') {
+      interval += 5000;
+      continue;
+    }
+    throw new Error(`Device token poll failed: ${JSON.stringify(poll.json)}`);
+  }
+  throw new Error('Device authorization expired before the user completed sign-in.');
+}
+
+// ---------------------------------------------------------------------------
+// Generic HTTP — authorization-code flow (two-step paste)
+// ---------------------------------------------------------------------------
+
+export interface HttpAuthCodeArgs {
+  manual: string;
+  authEndpoint: string;
+  tokenEndpoint: string;
+  clientId: string;
+  scope?: string;
+  redirect: string;
+  envPath: string;
+  envKey: string;
+}
+
+export async function httpAuthCodeStart(a: HttpAuthCodeArgs): Promise<void> {
+  const codeVerifier = b64url(crypto.randomBytes(32));
+  const codeChallenge = b64url(crypto.createHash('sha256').update(codeVerifier).digest());
+  const state = b64url(crypto.randomBytes(16));
+  const url = new URL(a.authEndpoint);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', a.clientId);
+  url.searchParams.set('redirect_uri', a.redirect);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+  if (a.scope) url.searchParams.set('scope', a.scope);
+
+  await saveState(a.manual, {
+    kind: 'http_authcode',
+    tokenEndpoint: a.tokenEndpoint,
+    clientId: a.clientId,
+    redirect: a.redirect,
+    codeVerifier,
+    state,
+    envPath: a.envPath,
+    envKey: a.envKey,
+  });
+  emit({
+    action: 'show_user_url',
+    url: url.href,
+    then: 'rerun_with_code',
+    next: `utcp login ${a.manual} --code "<pasted code or redirect URL>"`,
+    message: `Tell the user to open the URL and sign in. After redirect to ${a.redirect}, have them copy the full address-bar URL (or the code) and pass it to the next command.`,
+  });
+}
+
+export async function loginFinishWithCode(manual: string, codeInput: string): Promise<void> {
+  const st = await loadState(manual);
+  if (!st) throw new Error(`No pending login for '${manual}'. Run \`utcp login ${manual}\` first.`);
+  const code = parseCodeFromInput(codeInput);
+
+  if (st.kind === 'http_authcode') {
+    const res = await postForm(st.tokenEndpoint, {
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: st.redirect,
+      client_id: st.clientId,
+      code_verifier: st.codeVerifier,
+    });
+    if (!res.json.access_token) throw new Error(`Token exchange failed: ${JSON.stringify(res.json)}`);
+    await upsertEnvVar(st.envPath, st.envKey, res.json.access_token);
+    if (res.json.refresh_token) await persistTokenMeta(manual, { refresh_token: res.json.refresh_token, client_id: st.clientId });
+    await clearState(manual);
+    emit({ action: 'done', wrote: st.envKey, env_file: st.envPath, message: 'Login complete.' });
+    return;
+  }
+
+  if (st.kind === 'mcp') {
+    const tokens = await exchangeAuthorization(st.authServerUrl, {
+      metadata: st.metadata,
+      clientInformation: st.clientInformation,
+      authorizationCode: code,
+      codeVerifier: st.codeVerifier,
+      redirectUri: st.redirect,
+      resource: st.resource ? new URL(st.resource) : undefined,
+    });
+    if (!tokens.access_token) throw new Error(`MCP token exchange returned no access_token: ${JSON.stringify(tokens)}`);
+    await upsertEnvVar(st.envPath, st.envKey, tokens.access_token);
+    await persistTokenMeta(manual, {
+      refresh_token: tokens.refresh_token,
+      client_id: st.clientInformation?.client_id,
+      authServerUrl: st.authServerUrl,
+    });
+    await clearState(manual);
+    emit({ action: 'done', wrote: st.envKey, env_file: st.envPath, message: 'MCP login complete.' });
+    return;
+  }
+
+  throw new Error(`Unknown pending login kind '${st.kind}' for '${manual}'.`);
+}
+
+// ---------------------------------------------------------------------------
+// MCP — discovery + dynamic client registration + PKCE (two-step paste)
+// ---------------------------------------------------------------------------
+
+export interface McpLoginArgs {
+  manual: string;
+  serverUrl: string;
+  scope?: string;
+  redirect: string;
+  envPath: string;
+  envKey: string;
+}
+
+export async function mcpLoginStart(a: McpLoginArgs): Promise<void> {
+  const resourceMeta = await discoverOAuthProtectedResourceMetadata(a.serverUrl).catch(() => undefined);
+  const authServerUrl = (resourceMeta?.authorization_servers && resourceMeta.authorization_servers[0]) || a.serverUrl;
+  const metadata = await discoverAuthorizationServerMetadata(authServerUrl);
+  if (!metadata) throw new Error(`Could not discover OAuth metadata for ${authServerUrl}.`);
+
+  const clientInformation = await registerClient(authServerUrl, {
+    metadata,
+    clientMetadata: {
+      client_name: `code-mode-cli (${a.manual})`,
+      redirect_uris: [a.redirect],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      ...(a.scope ? { scope: a.scope } : {}),
+    },
+  });
+
+  const resource = new URL((resourceMeta as any)?.resource || a.serverUrl);
+  const { authorizationUrl, codeVerifier } = await startAuthorization(authServerUrl, {
+    metadata,
+    clientInformation,
+    redirectUrl: a.redirect,
+    scope: a.scope,
+    resource,
+  });
+
+  await saveState(a.manual, {
+    kind: 'mcp',
+    authServerUrl,
+    metadata,
+    clientInformation,
+    codeVerifier,
+    redirect: a.redirect,
+    resource: resource.href,
+    envPath: a.envPath,
+    envKey: a.envKey,
+  });
+  emit({
+    action: 'show_user_url',
+    url: authorizationUrl.href,
+    then: 'rerun_with_code',
+    next: `utcp login ${a.manual} --code "<pasted code or redirect URL>"`,
+    message: `Tell the user to open the URL and authorize. After redirect to ${a.redirect}, have them copy the full address-bar URL (or the code) and pass it to the next command.`,
+  });
+}

--- a/code-mode-cli/src/oauth.ts
+++ b/code-mode-cli/src/oauth.ts
@@ -93,19 +93,24 @@ async function persistTokenMeta(manual: string, meta: Record<string, any>): Prom
 // helpers
 // ---------------------------------------------------------------------------
 
-/** Accepts a bare code or a full pasted redirect URL and returns the code. */
-export function parseCodeFromInput(input: string): string {
+/** Reads a query param from a pasted redirect URL (or bare `?k=v` fragment). */
+function paramFromInput(input: string, name: string): string | null {
   const trimmed = input.trim();
   if (trimmed.includes('://') || trimmed.includes('?')) {
     try {
       const url = new URL(trimmed.includes('://') ? trimmed : `http://x/${trimmed}`);
-      const code = url.searchParams.get('code');
-      if (code) return code;
+      return url.searchParams.get(name);
     } catch {
-      /* not a URL, treat as raw code */
+      /* not a URL */
     }
   }
-  return trimmed;
+  return null;
+}
+
+/** Accepts a bare code or a full pasted redirect URL and returns the code. */
+export function parseCodeFromInput(input: string): string {
+  const code = paramFromInput(input, 'code');
+  return code ?? input.trim();
 }
 
 function b64url(buf: Buffer): string {
@@ -243,6 +248,16 @@ export async function loginFinishWithCode(manual: string, codeInput: string): Pr
   if (!st) throw new Error(`No pending login for '${manual}'. Run \`utcp login ${manual}\` first.`);
   const code = parseCodeFromInput(codeInput);
 
+  // CSRF / response-binding check: if we issued a `state` and the user pasted the
+  // full redirect URL (which carries `state`), it must match what we stored. A
+  // bare code paste has no state to compare, so it can't be verified.
+  if (st.state) {
+    const returnedState = paramFromInput(codeInput, 'state');
+    if (returnedState && returnedState !== st.state) {
+      throw new Error('OAuth state mismatch — aborting login (possible CSRF, or a stale/wrong link). Restart with `utcp login`.');
+    }
+  }
+
   if (st.kind === 'http_authcode') {
     const res = await postForm(st.tokenEndpoint, {
       grant_type: 'authorization_code',
@@ -315,11 +330,13 @@ export async function mcpLoginStart(a: McpLoginArgs): Promise<void> {
   });
 
   const resource = new URL((resourceMeta as any)?.resource || a.serverUrl);
+  const state = b64url(crypto.randomBytes(16));
   const { authorizationUrl, codeVerifier } = await startAuthorization(authServerUrl, {
     metadata,
     clientInformation,
     redirectUrl: a.redirect,
     scope: a.scope,
+    state,
     resource,
   });
 
@@ -329,6 +346,7 @@ export async function mcpLoginStart(a: McpLoginArgs): Promise<void> {
     metadata,
     clientInformation,
     codeVerifier,
+    state,
     redirect: a.redirect,
     resource: resource.href,
     envPath: a.envPath,

--- a/code-mode-cli/src/validate.ts
+++ b/code-mode-cli/src/validate.ts
@@ -31,7 +31,15 @@ export async function validateConfig(configFlag: string | undefined, offline: bo
     return { valid: false, error: `Config is invalid: ${e.message}` };
   }
 
-  const manuals: any[] = (rawConfig as any).manual_call_templates || [];
+  const rawManuals = (rawConfig as any).manual_call_templates;
+  if (rawManuals !== undefined && !Array.isArray(rawManuals)) {
+    return {
+      valid: false,
+      config_path: configPath,
+      error: `"manual_call_templates" must be an array, got ${typeof rawManuals}.`,
+    };
+  }
+  const manuals: any[] = rawManuals || [];
   const reports: ManualReport[] = [];
   const ser = new CallTemplateSerializer();
 

--- a/code-mode-cli/src/validate.ts
+++ b/code-mode-cli/src/validate.ts
@@ -1,0 +1,91 @@
+// `utcp validate` — give an agent fast feedback on config/manuals it wrote,
+// without it having to reason about a full registration round-trip.
+//
+//   validate                 → validate the active .utcp_config.json: the config
+//                              shape + each manual call template, then (unless
+//                              --offline) register each manual and report how
+//                              many tools it yields.
+//   validate --manual <f...> → validate standalone UTCP manual file(s) (the JSON
+//                              an agent authors for a `file` call template).
+import { promises as fs } from 'fs';
+import { CallTemplateSerializer, UtcpManualSerializer, ensureCorePluginsInitialized } from '@utcp/sdk';
+import { createClient } from './config.js';
+
+export interface ManualReport {
+  name: string;
+  call_template_type?: string;
+  structure_valid: boolean;
+  registered?: boolean;
+  tool_count?: number;
+  errors: string[];
+}
+
+/** Validate the active config and its manuals. */
+export async function validateConfig(configFlag: string | undefined, offline: boolean): Promise<any> {
+  let client, rawConfig, configPath;
+  try {
+    // skipManualRegistration: validates the config shape but lets us register
+    // each manual individually below to capture per-manual results.
+    ({ client, rawConfig, configPath } = await createClient(configFlag, { skipManualRegistration: true }));
+  } catch (e: any) {
+    return { valid: false, error: `Config is invalid: ${e.message}` };
+  }
+
+  const manuals: any[] = (rawConfig as any).manual_call_templates || [];
+  const reports: ManualReport[] = [];
+  const ser = new CallTemplateSerializer();
+
+  for (const m of manuals) {
+    const report: ManualReport = {
+      name: m?.name ?? '(unnamed)',
+      call_template_type: m?.call_template_type,
+      structure_valid: false,
+      errors: [],
+    };
+    try {
+      ser.validateDict(m);
+      report.structure_valid = true;
+    } catch (e: any) {
+      report.errors.push(`Invalid call template: ${e.message}`);
+    }
+
+    if (report.structure_valid && !offline) {
+      try {
+        const result = await client.registerManual(m);
+        report.registered = result.success;
+        report.tool_count = result.manual?.tools?.length ?? 0;
+        if (!result.success) report.errors.push(...(result.errors || []));
+      } catch (e: any) {
+        report.registered = false;
+        report.errors.push(`Registration failed: ${e.message}`);
+      }
+    }
+    reports.push(report);
+  }
+
+  await client.close().catch(() => {});
+
+  const valid = reports.every((r) => r.structure_valid && (offline || r.registered !== false));
+  return { valid, config_path: configPath, offline, manuals: reports };
+}
+
+/** Validate standalone UTCP manual files (JSON). */
+export async function validateManualFiles(paths: string[]): Promise<any> {
+  ensureCorePluginsInitialized();
+  const ser = new UtcpManualSerializer();
+  const results = [];
+  for (const p of paths) {
+    const entry: any = { file: p, valid: false, errors: [] };
+    try {
+      const parsed = JSON.parse(await fs.readFile(p, 'utf-8'));
+      const manual = ser.validateDict(parsed);
+      entry.valid = true;
+      entry.tool_count = manual.tools.length;
+      entry.tools = manual.tools.map((t: any) => t.name);
+    } catch (e: any) {
+      entry.errors.push(e.message);
+    }
+    results.push(entry);
+  }
+  return { valid: results.every((r) => r.valid), manuals: results };
+}

--- a/code-mode-cli/tsconfig.json
+++ b/code-mode-cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "declaration": false,
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/code-mode-cli/tsconfig.json
+++ b/code-mode-cli/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "outDir": "./dist",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce the `utcp` CLI (`@utcp/code-mode-cli`) to run Code Mode tools from any shell. Agents can discover tools, execute TypeScript tool-chains in a sandbox, and complete OAuth logins without MCP. The top-level README now recommends this flow for shell-based agents.

- **New Features**
  - New package `@utcp/code-mode-cli` with `utcp` binary.
  - Commands: `prompt`, `search`, `run`, `login`, `validate`.
  - Self-configuration via `.utcp_config.json`; `.env` loading through `@utcp/dotenv-loader`.
  - OAuth device and auth-code (PKCE) flows for HTTP and MCP manuals with dynamic client registration; tokens written to `.env`.
  - Sandbox execution using `isolated-vm`; stdout is JSON (NDJSON for `login`); errors as JSON; diagnostics to stderr.
  - Stable TypeScript tool names aligned with the Code Mode MCP bridge.
  - Added `code-mode-cli/README.md`, `SKILL.md`; MIT license.

- **Migration**
  - For shell agents: run `npx -y @utcp/code-mode-cli prompt`, write `.utcp_config.json`, then use `utcp validate`, `utcp search`, `utcp run`, and `utcp login` as needed. MCP config and env vars are not required.

<sup>Written for commit 9e3d1d6192441c3003e79471ad79d059dcc5b1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/code-mode/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

